### PR TITLE
Fix user defiend modifier tests

### DIFF
--- a/Sources/Demo/main.swift
+++ b/Sources/Demo/main.swift
@@ -35,8 +35,8 @@ struct ChildView: View {
                 }
             }
         }
-        .border(.red)
-        .border(.yellow)
+        .border(.cyan)
+        .border(.green)
     }
 }
 

--- a/Sources/Demo/main.swift
+++ b/Sources/Demo/main.swift
@@ -3,21 +3,24 @@ import Foundation
 import cncurses
 import Runtime
 
-struct ContentView: View {
-    var x: State<Bool>
-    init(state: State<Bool>) {
-        self.x = state
+struct Modifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .border(Color.yellow)
+            .padding(1)
+            .border(Color.red)
+            .frame(width: 7, height: 7)
+            .border(Color.blue)
     }
+}
+struct ChildView: View {
+    @Binding var binding: Bool
     var body: some View {
-        VStack(alignment: .leading) {
-            if x.wrappedValue {
+        VStack {
+            if binding {
                 Text("Hello")
                 Text(",")
-                    .border(Color.yellow)
-                    .padding(1)
-                    .border(Color.red)
-                    .frame(width: 7, height: 7)
-                    .border(Color.blue)
+                    .modifier(Modifier())
                 VStack(alignment: .trailing) {
                     Text("World")
                         .frame(width: 4, height: 3)
@@ -25,11 +28,7 @@ struct ContentView: View {
             } else {
                 Text("World")
                 Text(",")
-                    .border(Color.yellow)
-                    .padding(1)
-                    .border(Color.red)
-                    .frame(width: 7, height: 7)
-                    .border(Color.blue)
+                    .modifier(Modifier())
                 VStack(alignment: .trailing) {
                     Text("Hello")
                         .frame(width: 4, height: 3)
@@ -40,8 +39,18 @@ struct ContentView: View {
         .border(.yellow)
     }
 }
+
+struct ParentView: View {
+    var state: State<Bool>
+    init(state: State<Bool>) {
+        self.state = state
+    }
+    var body: some View {
+        ChildView(binding: state.projectedValue)
+    }
+}
 var state = State(initialValue: false)
-let view = ContentView(state: state)
+let view = ParentView(state: state)
 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
     state.wrappedValue = true
     state.update()

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -60,7 +60,8 @@ extension ModifiedContent: ViewGraphSetAttributeAcceptable {
         if isUserDefinedModifier {
             let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
             graph.setModifier(bodyGraph)
-            bodyGraph.setModifier(contentGraph)
+            bodyGraph.putModifier(contentGraph)
+            return graph
         } else {
             graph.setModifier(contentGraph)
         }

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -30,12 +30,14 @@ extension ModifiedContent: ViewContentAcceptable {
             return
         }
 
-        let body = modifier.body(content: _ViewModifier_Content())
-        if let acceptable = body as? ViewContentAcceptable {
-            acceptable.accept(visitor: visitor)
+        if content is UserDefinedViewModifierContent {
+            assert(visitor.current?.children.count == 0)
+            visitor.current?.children.forEach(visitor.visit)
             return
         }
-
+        if !(modifier is Primitive) {
+            return
+        }
         fatalError("Unexpected ModifiedContent of \(type(of: self)), and modifier type \(type(of: modifier)), and content type \(type(of: content))")
     }
 }

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -49,6 +49,9 @@ extension ModifiedContent: View {
 extension ModifiedContent: Rendable where Modifier: Rendable { }
 extension ModifiedContent: ContainerViewType where Modifier: ContainerViewType { }
 extension ModifiedContent: ViewGraphSetAttributeAcceptable {
+    private var isUserDefinedModifier: Bool {
+        return !(modifier is Primitive)
+    }
     internal func accept(visitor: ViewGraphSetVisitor) -> ViewGraph {
         let graph = ViewGraphImpl(view: self)
         visitor.current?.addChild(graph)
@@ -56,10 +59,10 @@ extension ModifiedContent: ViewGraphSetAttributeAcceptable {
         defer { visitor.current = keepCurrent }
         visitor.current = graph
         let contentGraph = visitor.visit(content)
-        if graph.isUserDefinedModifier {
+        if isUserDefinedModifier {
             let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
             graph.setModifier(bodyGraph)
-            bodyGraph.children[0].addChild(contentGraph)
+            bodyGraph.extractUserDefinedModifierContentChild()!.addChild(contentGraph)
             return graph
         }
         

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -47,16 +47,27 @@ extension ModifiedContent: View {
 extension ModifiedContent: Rendable where Modifier: Rendable { }
 extension ModifiedContent: ContainerViewType where Modifier: ContainerViewType { }
 extension ModifiedContent: ViewGraphSetAttributeAcceptable {
+    private var isUserDefinedModifier: Bool {
+        !(modifier is Primitive)
+    }
     internal func accept(visitor: ViewGraphSetVisitor) -> ViewGraph {
         let graph = ViewGraphImpl(view: self)
         visitor.current?.addChild(graph)
         let keepCurrent = visitor.current
         defer { visitor.current = keepCurrent }
         visitor.current = graph
-        let contengGraph = visitor.visit(content)
-        graph.setModifier(contengGraph)
-        if let modifier = modifier as? _FrameLayout {
-            contengGraph.alignment = modifier.alignment
+        if isUserDefinedModifier {
+            let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
+            graph.setModifier(bodyGraph)
+            
+            let contengGraph = visitor.visit(content)
+            bodyGraph.setModifier(contengGraph)
+        } else {
+            let contengGraph = visitor.visit(content)
+            graph.setModifier(contengGraph)
+            if let modifier = modifier as? _FrameLayout {
+                contengGraph.alignment = modifier.alignment
+            }
         }
         return graph
     }

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -49,9 +49,6 @@ extension ModifiedContent: View {
 extension ModifiedContent: Rendable where Modifier: Rendable { }
 extension ModifiedContent: ContainerViewType where Modifier: ContainerViewType { }
 extension ModifiedContent: ViewGraphSetAttributeAcceptable {
-    private var isUserDefinedModifier: Bool {
-        !(modifier is Primitive)
-    }
     internal func accept(visitor: ViewGraphSetVisitor) -> ViewGraph {
         let graph = ViewGraphImpl(view: self)
         visitor.current?.addChild(graph)
@@ -59,7 +56,7 @@ extension ModifiedContent: ViewGraphSetAttributeAcceptable {
         defer { visitor.current = keepCurrent }
         visitor.current = graph
         let contentGraph = visitor.visit(content)
-        if isUserDefinedModifier {
+        if graph.isUserDefinedModifier {
             let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
             graph.setModifier(bodyGraph)
             bodyGraph.children[0].addChild(contentGraph)

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -60,11 +60,11 @@ extension ModifiedContent: ViewGraphSetAttributeAcceptable {
         if isUserDefinedModifier {
             let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
             graph.setModifier(bodyGraph)
-            bodyGraph.putModifier(contentGraph)
+            bodyGraph.children[0].addChild(contentGraph)
             return graph
-        } else {
-            graph.setModifier(contentGraph)
         }
+        
+        graph.setModifier(contentGraph)
         if let modifier = modifier as? _FrameLayout {
             contentGraph.alignment = modifier.alignment
         }

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -56,18 +56,16 @@ extension ModifiedContent: ViewGraphSetAttributeAcceptable {
         let keepCurrent = visitor.current
         defer { visitor.current = keepCurrent }
         visitor.current = graph
+        let contentGraph = visitor.visit(content)
         if isUserDefinedModifier {
             let bodyGraph = visitor.visit(modifier.body(content: _ViewModifier_Content()))
             graph.setModifier(bodyGraph)
-            
-            let contengGraph = visitor.visit(content)
-            bodyGraph.setModifier(contengGraph)
+            bodyGraph.setModifier(contentGraph)
         } else {
-            let contengGraph = visitor.visit(content)
-            graph.setModifier(contengGraph)
-            if let modifier = modifier as? _FrameLayout {
-                contengGraph.alignment = modifier.alignment
-            }
+            graph.setModifier(contentGraph)
+        }
+        if let modifier = modifier as? _FrameLayout {
+            contentGraph.alignment = modifier.alignment
         }
         return graph
     }

--- a/Sources/SwiftTUI/Core/ViewModifier.swift
+++ b/Sources/SwiftTUI/Core/ViewModifier.swift
@@ -33,3 +33,9 @@ extension _ViewModifier_Content: ViewGraphSetAcceptable {
         return graph
     }
 }
+
+
+internal protocol UserDefinedViewModifierContent {
+    
+}
+extension _ViewModifier_Content: UserDefinedViewModifierContent { }

--- a/Sources/SwiftTUI/Core/ViewModifier.swift
+++ b/Sources/SwiftTUI/Core/ViewModifier.swift
@@ -33,4 +33,3 @@ extension _ViewModifier_Content: ViewGraphSetAcceptable {
         return graph
     }
 }
-extension _ViewModifier_Content: ViewSetRectVisitorSkip { }

--- a/Sources/SwiftTUI/Core/ViewModifier.swift
+++ b/Sources/SwiftTUI/Core/ViewModifier.swift
@@ -22,3 +22,15 @@ extension ViewModifier where Body == Never {
         fatalError("body is never. received argument \(content)")
     }
 }
+
+extension _ViewModifier_Content: ViewGraphSetAcceptable {
+    func accept(visitor: ViewGraphSetVisitor) -> ViewGraph {
+        let graph = ViewGraphImpl(view: self)
+        visitor.current?.addChild(graph)
+        let keepCurrent = visitor.current
+        defer { visitor.current = keepCurrent }
+        visitor.current = graph
+        return graph
+    }
+}
+extension _ViewModifier_Content: ViewSetRectVisitorSkip { }

--- a/Sources/SwiftTUI/View/Modifier/AlignmentWritingModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/AlignmentWritingModifier.swift
@@ -34,3 +34,5 @@ extension _AlignmentWritingModifier: ViewContentAcceptable {
         
     }
 }
+
+extension _AlignmentWritingModifier: Primitive { }

--- a/Sources/SwiftTUI/View/Modifier/BackgroundModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BackgroundModifier.swift
@@ -37,3 +37,5 @@ extension _BackgroundModifier: ViewContentAcceptable {
         }
     }
 }
+
+extension _BackgroundModifier: Primitive { }

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -49,6 +49,7 @@ extension Edge.Set {
 }
 
 extension _BorderModifier: Rendable { }
+extension _BorderModifier: Primitive { }
 fileprivate let defaultBorderWidth: PhysicalDistance = 1
 internal extension _BorderModifier {
     func modify(for graph: ViewGraph, visitor: ViewSetRectVisitor) {

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -84,8 +84,8 @@ internal extension _BorderModifier {
 }
 extension _BorderModifier: ViewContentAcceptable {
     func accept(visitor: ViewContentVisitor) {
-        guard let graph = visitor.current, let modifier = graph.anyView as? HasAnyModifier, modifier.anyModifier is _BorderModifier else {
-            fatalError("visitor.current should _BorderModifier type but actually current is \(String(describing: visitor.current))")
+        guard let graph = visitor.current else {
+            fatalError("visitor.current necessary but it is nil")
         }
         let position = graph.positionToWindow()
         

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -84,7 +84,7 @@ internal extension _BorderModifier {
 extension _BorderModifier: ViewContentAcceptable {
     func accept(visitor: ViewContentVisitor) {
         guard let graph = visitor.current, let modifier = graph.anyView as? HasAnyModifier, modifier.anyModifier is _BorderModifier else {
-            fatalError("visitor.current should _BorderModifier type but actually type of \(type(of: visitor.current))")
+            fatalError("visitor.current should _BorderModifier type but actually current is \(String(describing: visitor.current))")
         }
         let position = graph.positionToWindow()
         

--- a/Sources/SwiftTUI/View/Modifier/FrameModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/FrameModifier.swift
@@ -34,6 +34,7 @@ internal extension _FrameLayout {
 }
 
 extension _FrameLayout: Rendable { }
+extension _FrameLayout: Primitive { }
 extension _FrameLayout: ContainerViewType { }
 extension _FrameLayout: ViewContentAcceptable {
     func accept(visitor: ViewContentVisitor) {

--- a/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
+++ b/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
@@ -96,6 +96,7 @@ internal extension _PaddingLayout {
 }
 
 extension _PaddingLayout: Rendable { }
+extension _PaddingLayout: Primitive { }
 extension _PaddingLayout: ViewContentAcceptable {
     func accept(visitor: ViewContentVisitor) {
         // NOTE: escape to reach ViewModifier.Body is Never

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -20,9 +20,6 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
             }
         }
         
-        if anyView is ViewSetRectVisitorSkip {
-            return
-        }
         if isRoot {
             setProposedSizeIfFirst(mainScreen.bounds.size)
         }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -9,6 +9,9 @@ import Foundation
 
 extension ViewGraph: ViewSetRectVisitorAcceptable {
     func accept(visitor: ViewSetRectVisitor) -> ViewSetRectVisitor.VisitResult {
+        let keepCurrent = visitor.current
+        defer { visitor.current = keepCurrent }
+        visitor.current = self
         defer {
             if isRoot {
                 acceptSetDimensions(visitor: visitor)
@@ -41,7 +44,7 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
                 return
             }
         }
-        
+
         if !children.isEmpty {
             children.forEach { $0.accept(visitor: visitor) }
             let size = children
@@ -56,6 +59,11 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
             rect.size = size
             return
         }
+        
+        if anyView is ViewSetRectVisitorSkip {
+            return
+        }
+        
         fatalError("unexpected pattern \(self)")
     }
 }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -23,10 +23,16 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
         if isRoot {
             setProposedSizeIfFirst(mainScreen.bounds.size)
         }
-        parent.map {
-            setProposedSizeIfFirst($0.proposedSize)
+        
+        var next = self.parent
+        while let parent = next {
+            next = parent.parent
+            if !parent.alreadyMarkedProposedSize() {
+                continue
+            }
+            setProposedSizeIfFirst(parent.proposedSize)
         }
-
+        
         if isModifiedContent {
             guard let view = anyView as? HasAnyModifier else {
                 fatalError("isModifiedContent is true but it has not anyModifier \(self)")

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -20,6 +20,9 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
             }
         }
         
+        if anyView is ViewSetRectVisitorSkip {
+            return
+        }
         if isRoot {
             setProposedSizeIfFirst(mainScreen.bounds.size)
         }
@@ -59,11 +62,7 @@ extension ViewGraph: ViewSetRectVisitorAcceptable {
             rect.size = size
             return
         }
-        
-        if anyView is ViewSetRectVisitorSkip {
-            return
-        }
-        
+
         fatalError("unexpected pattern \(self)")
     }
 }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -97,8 +97,12 @@ extension ViewGraph {
         if children.isEmpty {
             return
         }
-        
+
         children.forEach { $0.acceptSetPosition(visitor: visitor) }
+        
+        if isUserDefinedModifierContent {
+            return
+        }
 
         if isModifiedContent {
             guard let view = anyView as? HasAnyModifier else {

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
@@ -48,6 +48,12 @@ public class ViewGraph: SwiftTUI.View {
         inheritProperties(to: node)
     }
 
+    internal func putModifier(_ modifierNode: ViewGraph) {
+        isModifiedContent = true
+        assert(children.count == 1)
+        children.removeFirst()
+        addChild(modifierNode)
+    }
     internal func setModifier(_ modifierNode: ViewGraph) {
         isModifiedContent = true
         addChild(modifierNode)

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
@@ -25,6 +25,12 @@ public class ViewGraph: SwiftTUI.View {
     internal var rect: Rect = Rect(origin: .zero, size: .zero)
     internal var proposedSize: Size = .zero
 
+    internal var isUserDefinedModifier: Bool {
+        guard let modifier = anyView as? HasAnyModifier else {
+            return false
+        }
+        return !(modifier.anyModifier is Primitive)
+    }
     internal func alreadyMarkedProposedSize() -> Bool {
         return proposedSizeMarker.isMarked(graph: self)
     }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
@@ -25,6 +25,9 @@ public class ViewGraph: SwiftTUI.View {
     internal var rect: Rect = Rect(origin: .zero, size: .zero)
     internal var proposedSize: Size = .zero
 
+    internal func alreadyMarkedProposedSize() -> Bool {
+        return proposedSizeMarker.isMarked(graph: self)
+    }
     internal func setProposedSizeIfFirst(_ size: Size) {
         if proposedSizeMarker.isMarked(graph: self) {
             return

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
@@ -48,12 +48,6 @@ public class ViewGraph: SwiftTUI.View {
         inheritProperties(to: node)
     }
 
-    internal func putModifier(_ modifierNode: ViewGraph) {
-        isModifiedContent = true
-        assert(children.count == 1)
-        children.removeFirst()
-        addChild(modifierNode)
-    }
     internal func setModifier(_ modifierNode: ViewGraph) {
         isModifiedContent = true
         addChild(modifierNode)

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph.swift
@@ -17,6 +17,7 @@ public class ViewGraph: SwiftTUI.View {
     internal var isModifiedContent: Bool = false
     internal var isContainerType: Bool { anyView is ContainerViewType }
     internal var isRendableType: Bool { anyView is Rendable }
+    internal var isUserDefinedModifierContent: Bool { anyView is UserDefinedViewModifierContent }
     
     internal var listType: ViewVisitorListOption = .default
     internal var alignment: Alignment = .default
@@ -25,11 +26,17 @@ public class ViewGraph: SwiftTUI.View {
     internal var rect: Rect = Rect(origin: .zero, size: .zero)
     internal var proposedSize: Size = .zero
 
-    internal var isUserDefinedModifier: Bool {
-        guard let modifier = anyView as? HasAnyModifier else {
-            return false
+    func _extractUserDefinedModifierContentChild(root: ViewGraph) -> ViewGraph? {
+        if isUserDefinedModifierContent && root !== self {
+            return self
         }
-        return !(modifier.anyModifier is Primitive)
+        if children.isEmpty {
+            return nil
+        }
+        return children.compactMap { $0._extractUserDefinedModifierContentChild(root: root) }.first
+    }
+    internal func extractUserDefinedModifierContentChild() -> ViewGraph? {
+        _extractUserDefinedModifierContentChild(root: self)
     }
     internal func alreadyMarkedProposedSize() -> Bool {
         return proposedSizeMarker.isMarked(graph: self)

--- a/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
@@ -11,6 +11,8 @@ internal protocol ViewSetRectVisitorAcceptable {
     func accept(visitor: ViewSetRectVisitor) -> ViewSetRectVisitor.VisitResult
 }
 
+internal protocol ViewSetRectVisitorSkip { }
+
 internal final class ViewSetRectVisitor: Visitor {
     internal typealias VisitResult = Void
     internal init() { }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
@@ -17,6 +17,7 @@ internal final class ViewSetRectVisitor: Visitor {
     internal typealias VisitResult = Void
     internal init() { }
     
+    internal var current: ViewGraph?
     internal var currentContainerGraph: ViewGraph?
 
     internal func visit<T: View>(_ content: T) -> VisitResult {
@@ -27,6 +28,8 @@ internal final class ViewSetRectVisitor: Visitor {
         switch content {
         case let acceptable as ViewSetRectVisitorAcceptable:
             return acceptable.accept(visitor: self)
+        case is ViewSetRectVisitorSkip:
+            return
         case _:
             return visit(content.body)
         }

--- a/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewSetRectVisitor.swift
@@ -11,8 +11,6 @@ internal protocol ViewSetRectVisitorAcceptable {
     func accept(visitor: ViewSetRectVisitor) -> ViewSetRectVisitor.VisitResult
 }
 
-internal protocol ViewSetRectVisitorSkip { }
-
 internal final class ViewSetRectVisitor: Visitor {
     internal typealias VisitResult = Void
     internal init() { }
@@ -28,8 +26,6 @@ internal final class ViewSetRectVisitor: Visitor {
         switch content {
         case let acceptable as ViewSetRectVisitorAcceptable:
             return acceptable.accept(visitor: self)
-        case is ViewSetRectVisitorSkip:
-            return
         case _:
             return visit(content.body)
         }

--- a/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
+++ b/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
@@ -159,4 +159,36 @@ class BorderModifierTests: XCTestCase {
             XCTAssertTrue(content.contains("World"))
         }
     }
+    
+    func testModifiers() {
+        struct Modifier: ViewModifier {
+            func body(content: Content) -> some View {
+                content.border(.red)
+            }
+        }
+        XCTContext.runActivity(named: "via custom ViewModifier") { (_) in
+            let view = Text("Hello").modifier(Modifier())
+
+            let graph = prepareSizedGraph(view: view)
+            let driver = Driver()
+            let visitor = ViewContentVisitor(driver: driver)
+            graph.accept(visitor: visitor)
+            
+            let content = driver.content()
+            let subject: (String) -> Int = { (delimiter: String) in
+                content.filter { String($0) == delimiter }.count
+            }
+            
+            assert(Edge.Set.leadingTop.defaultDelimiter == Edge.Set.trailingTop.defaultDelimiter && Edge.Set.trailingTop.defaultDelimiter == Edge.Set.trailingBottom.defaultDelimiter && Edge.Set.trailingBottom.defaultDelimiter == Edge.Set.leadingBottom.defaultDelimiter, "this test case need the same corner defaultDelimiter")
+            let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
+            
+            XCTAssertTrue(driver.storedForegroundColors.contains(.red))
+            XCTAssertEqual(driver.storedForegroundColors.last, Style.Color.foreground.color)
+            XCTAssertEqual(subject(cornerDelimiter), 1 * 4)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 1 * 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 5 * 2)
+            XCTAssertTrue(content.contains("Hello"))
+        }
+
+    }
 }

--- a/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
+++ b/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
@@ -16,6 +16,11 @@ class BorderModifierTests: XCTestCase {
         mainScreen = DummyScreen.init()
     }
     
+    func testTODO() {
+        // NOTE: keep assertion when resolved TODO
+        assert(Edge.Set.leadingTop.defaultDelimiter == Edge.Set.trailingTop.defaultDelimiter && Edge.Set.trailingTop.defaultDelimiter == Edge.Set.trailingBottom.defaultDelimiter && Edge.Set.trailingBottom.defaultDelimiter == Edge.Set.leadingBottom.defaultDelimiter, "this test case need the same corner defaultDelimiter")
+    }
+    
     func testSize() throws {
         XCTContext.runActivity(named: "when call border(.blue)") { (_) in
             let view = Text("123").border(.blue)
@@ -145,7 +150,6 @@ class BorderModifierTests: XCTestCase {
                 content.filter { String($0) == delimiter }.count
             }
             
-            assert(Edge.Set.leadingTop.defaultDelimiter == Edge.Set.trailingTop.defaultDelimiter && Edge.Set.trailingTop.defaultDelimiter == Edge.Set.trailingBottom.defaultDelimiter && Edge.Set.trailingBottom.defaultDelimiter == Edge.Set.leadingBottom.defaultDelimiter, "this test case need the same corner defaultDelimiter")
             let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
             
             XCTAssertTrue(driver.storedForegroundColors.contains(.blue))
@@ -179,7 +183,6 @@ class BorderModifierTests: XCTestCase {
                 content.filter { String($0) == delimiter }.count
             }
             
-            assert(Edge.Set.leadingTop.defaultDelimiter == Edge.Set.trailingTop.defaultDelimiter && Edge.Set.trailingTop.defaultDelimiter == Edge.Set.trailingBottom.defaultDelimiter && Edge.Set.trailingBottom.defaultDelimiter == Edge.Set.leadingBottom.defaultDelimiter, "this test case need the same corner defaultDelimiter")
             let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
             
             XCTAssertTrue(driver.storedForegroundColors.contains(.red))

--- a/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
+++ b/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwiftTUI
 
-fileprivate let defaultBorderWidth = 1
+internal let defaultBorderWidth = 1
 class BorderModifierTests: XCTestCase {
     override func setUp() {
         super.setUp()

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -33,6 +33,36 @@ class CustomModifierContentTests: XCTestCase {
             XCTAssertTrue(wrappedModifier.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>)
             XCTAssertEqual(wrappedModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
+        
     }
+    
+    func test_playground() {
+        XCTContext.runActivity(named: "with border.border.border modifier") { _ in
+            struct Modifier: ViewModifier {
+                func body(content: Content) -> some View {
+                    content.border(.red).border(.yellow).border(.blue)
+                }
+            }
+            let view = Text("text").modifier(Modifier())
+
+            let graph = prepareViewGraph(view: view)
+            graph.accept(visitor: ViewSetRectVisitor())
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, Modifier>)
+            XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2 + 2 + 2, height: "text".height + 2 + 2 + 2))
+
+            let blue = graph.children[0]
+            XCTAssertTrue(blue.anyView is ModifiedContent<ModifiedContent<ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertEqual(blue.rect.size, Size(width: "text".width + 2 + 2 + 2, height: "text".height + 2 + 2 + 2))
+            
+            let yellow = blue.children[0]
+            XCTAssertTrue(yellow.anyView is ModifiedContent<ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertEqual(yellow.rect.size, Size(width: "text".width + 2 + 2, height: "text".height + 2 + 2))
+            
+            let red = yellow.children[0]
+            XCTAssertTrue(red.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>)
+            XCTAssertEqual(red.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
+        }
+    }
+    
 
 }

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -61,5 +61,60 @@ class CustomModifierContentTests: XCTestCase {
         }
     }
     
+    func testContent() throws {
+        XCTContext.runActivity(named: "with border modifier") { _ in
+            struct Modifier: ViewModifier {
+                func body(content: Content) -> some View {
+                    content.border(.red)
+                }
+            }
+            let view = Text("text").modifier(Modifier())
+            
+            let graph = prepareSizedGraph(view: view)
+            let driver = Driver()
+            graph.accept(visitor: ViewContentVisitor(driver: driver))
+            
+            let content = driver.content()
+            let subject: (String) -> Int = { (delimiter: String) in
+                content.filter { String($0) == delimiter }.count
+            }
+            
+            let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
+            
+            XCTAssertTrue(driver.storedForegroundColors.contains(.red))
+            XCTAssertEqual(driver.storedForegroundColors.last, Style.Color.foreground.color)
+            XCTAssertEqual(subject(cornerDelimiter), 4)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 1 * 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 4 * 2)
+            XCTAssertTrue(content.contains("text"))
+        }
+        
+        XCTContext.runActivity(named: "with border.border.border modifier") { _ in
+            struct Modifier: ViewModifier {
+                func body(content: Content) -> some View {
+                    content.border(.red).border(.yellow).border(.blue)
+                }
+            }
+            let view = Text("text").modifier(Modifier())
+            
+            let graph = prepareSizedGraph(view: view)
+            let driver = Driver()
+            graph.accept(visitor: ViewContentVisitor(driver: driver))
+            
+            let content = driver.content()
+            let subject: (String) -> Int = { (delimiter: String) in
+                content.filter { String($0) == delimiter }.count
+            }
+            
+            let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
+            
+            XCTAssertTrue(driver.storedForegroundColors.contains(.red))
+            XCTAssertEqual(driver.storedForegroundColors.last, Style.Color.foreground.color)
+            XCTAssertEqual(subject(cornerDelimiter), 4 * 3)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 1 * 2 + 3 * 2 + 5 * 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 4 * 2 + 6 * 2 + 8 * 2)
+            XCTAssertTrue(content.contains("text"))
+        }
+    }
 
 }

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -8,6 +8,11 @@
 import XCTest
 @testable import SwiftTUI
 
+fileprivate struct SingleBorderModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.border(.red)
+    }
+}
 class CustomModifierContentTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -17,20 +22,15 @@ class CustomModifierContentTests: XCTestCase {
 
     func testSize() throws {
         XCTContext.runActivity(named: "with border modifier") { _ in
-            struct Modifier: ViewModifier {
-                func body(content: Content) -> some View {
-                    content.border(.red)
-                }
-            }
-            let view = Text("text").modifier(Modifier())
+            let view = Text("text").modifier(SingleBorderModifier())
             
             let graph = prepareViewGraph(view: view)
             graph.accept(visitor: ViewSetRectVisitor())
-            XCTAssertTrue(graph.anyView is ModifiedContent<Text, Modifier>)
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, SingleBorderModifier>)
             XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
             
             let wrappedModifier = graph.children[0]
-            XCTAssertTrue(wrappedModifier.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>)
+            XCTAssertTrue(wrappedModifier.anyView is ModifiedContent<_ViewModifier_Content<SingleBorderModifier>, _BorderModifier>)
             XCTAssertEqual(wrappedModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
         
@@ -63,12 +63,7 @@ class CustomModifierContentTests: XCTestCase {
     
     func testContent() throws {
         XCTContext.runActivity(named: "with border modifier") { _ in
-            struct Modifier: ViewModifier {
-                func body(content: Content) -> some View {
-                    content.border(.red)
-                }
-            }
-            let view = Text("text").modifier(Modifier())
+            let view = Text("text").modifier(SingleBorderModifier())
             
             let graph = prepareSizedGraph(view: view)
             let driver = Driver()

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -34,9 +34,6 @@ class CustomModifierContentTests: XCTestCase {
             XCTAssertEqual(wrappedModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
         
-    }
-    
-    func test_playground() {
         XCTContext.runActivity(named: "with border.border.border modifier") { _ in
             struct Modifier: ViewModifier {
                 func body(content: Content) -> some View {

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -1,5 +1,5 @@
 //
-//  ModifierContentTests.swift
+//  CustomModifierContentTests.swift
 //  SwiftTUITests
 //
 //  Created by Yudai.Hirose on 2020/04/12.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import SwiftTUI
 
-class ModifierContentTests: XCTestCase {
+class CustomModifierContentTests: XCTestCase {
     override func setUp() {
         super.setUp()
         

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -83,6 +83,35 @@ class CustomModifierContentTests: XCTestCase {
             XCTAssertTrue(textGraph.anyView is Text)
             XCTAssertEqual(textGraph.rect.origin, Point(x: defaultBorderWidth, y: defaultBorderWidth))
         }
+        XCTContext.runActivity(named: "with border.border.border modifier") { _ in
+            let view = Text("123").modifier(ThreeBorderModifier())
+            
+            let graph = prepareViewGraph(view: view)
+            let visitor = ViewSetRectVisitor()
+            graph.accept(visitor: visitor)
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, ThreeBorderModifier>)
+            XCTAssertEqual(graph.rect.origin, .zero)
+            
+            let blue = graph.children[0]
+            XCTAssertTrue(blue.anyView is ModifiedContent<ModifiedContent<ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertEqual(blue.rect.origin, .zero)
+
+            let yellow = blue.children[0]
+            XCTAssertTrue(yellow.anyView is ModifiedContent<ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertEqual(yellow.rect.origin, Point(x: defaultBorderWidth, y: defaultBorderWidth))
+
+            let red = yellow.children[0]
+            XCTAssertTrue(red.anyView is ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>)
+            XCTAssertEqual(red.rect.origin, Point(x: defaultBorderWidth, y: defaultBorderWidth))
+
+            let modifierContentGraph = red.children[0]
+            XCTAssertTrue(modifierContentGraph.anyView is _ViewModifier_Content<ThreeBorderModifier>)
+            XCTAssertEqual(modifierContentGraph.rect.origin, .zero)
+            
+            let textGraph = modifierContentGraph.children[0]
+            XCTAssertTrue(textGraph.anyView is Text)
+            XCTAssertEqual(textGraph.rect.origin, Point(x: defaultBorderWidth, y: defaultBorderWidth))
+        }
     }
     
     func testContent() throws {

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -61,6 +61,30 @@ class CustomModifierContentTests: XCTestCase {
         }
     }
     
+    func testChlidrenPosition() throws {
+        XCTContext.runActivity(named: "with border modifier") { _ in
+            let view = Text("123").modifier(SingleBorderModifier())
+            
+            let graph = prepareViewGraph(view: view)
+            let visitor = ViewSetRectVisitor()
+            graph.accept(visitor: visitor)
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, SingleBorderModifier>)
+            XCTAssertEqual(graph.rect.origin, .zero)
+
+            let modifierGraph = graph.children[0]
+            XCTAssertTrue(modifierGraph.anyView is ModifiedContent<_ViewModifier_Content<SingleBorderModifier>, _BorderModifier>)
+            XCTAssertEqual(modifierGraph.rect.origin, .zero)
+            
+            let modifierContentGraph = modifierGraph.children[0]
+            XCTAssertTrue(modifierContentGraph.anyView is _ViewModifier_Content<SingleBorderModifier>)
+            XCTAssertEqual(modifierContentGraph.rect.origin, .zero)
+            
+            let textGraph = modifierContentGraph.children[0]
+            XCTAssertTrue(textGraph.anyView is Text)
+            XCTAssertEqual(textGraph.rect.origin, Point(x: defaultBorderWidth, y: defaultBorderWidth))
+        }
+    }
+    
     func testContent() throws {
         XCTContext.runActivity(named: "with border modifier") { _ in
             let view = Text("text").modifier(SingleBorderModifier())

--- a/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/CustomModifierContentTests.swift
@@ -13,6 +13,11 @@ fileprivate struct SingleBorderModifier: ViewModifier {
         content.border(.red)
     }
 }
+fileprivate struct ThreeBorderModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.border(.red).border(.yellow).border(.blue)
+    }
+}
 class CustomModifierContentTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -35,28 +40,23 @@ class CustomModifierContentTests: XCTestCase {
         }
         
         XCTContext.runActivity(named: "with border.border.border modifier") { _ in
-            struct Modifier: ViewModifier {
-                func body(content: Content) -> some View {
-                    content.border(.red).border(.yellow).border(.blue)
-                }
-            }
-            let view = Text("text").modifier(Modifier())
+            let view = Text("text").modifier(ThreeBorderModifier())
 
             let graph = prepareViewGraph(view: view)
             graph.accept(visitor: ViewSetRectVisitor())
-            XCTAssertTrue(graph.anyView is ModifiedContent<Text, Modifier>)
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, ThreeBorderModifier>)
             XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2 + 2 + 2, height: "text".height + 2 + 2 + 2))
 
             let blue = graph.children[0]
-            XCTAssertTrue(blue.anyView is ModifiedContent<ModifiedContent<ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertTrue(blue.anyView is ModifiedContent<ModifiedContent<ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>, _BorderModifier>, _BorderModifier>)
             XCTAssertEqual(blue.rect.size, Size(width: "text".width + 2 + 2 + 2, height: "text".height + 2 + 2 + 2))
             
             let yellow = blue.children[0]
-            XCTAssertTrue(yellow.anyView is ModifiedContent<ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>, _BorderModifier>)
+            XCTAssertTrue(yellow.anyView is ModifiedContent<ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>, _BorderModifier>)
             XCTAssertEqual(yellow.rect.size, Size(width: "text".width + 2 + 2, height: "text".height + 2 + 2))
             
             let red = yellow.children[0]
-            XCTAssertTrue(red.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>)
+            XCTAssertTrue(red.anyView is ModifiedContent<_ViewModifier_Content<ThreeBorderModifier>, _BorderModifier>)
             XCTAssertEqual(red.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
     }
@@ -85,12 +85,7 @@ class CustomModifierContentTests: XCTestCase {
         }
         
         XCTContext.runActivity(named: "with border.border.border modifier") { _ in
-            struct Modifier: ViewModifier {
-                func body(content: Content) -> some View {
-                    content.border(.red).border(.yellow).border(.blue)
-                }
-            }
-            let view = Text("text").modifier(Modifier())
+            let view = Text("text").modifier(ThreeBorderModifier())
             
             let graph = prepareSizedGraph(view: view)
             let driver = Driver()

--- a/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
@@ -17,22 +17,21 @@ class ModifierContentTests: XCTestCase {
 
     func testSize() throws {
         XCTContext.runActivity(named: "with border modifier") { _ in
-            struct BorderModifier: ViewModifier {
+            struct Modifier: ViewModifier {
                 func body(content: Content) -> some View {
                     content.border(.red)
                 }
             }
-            let view = Text("text").modifier(BorderModifier())
+            let view = Text("text").modifier(Modifier())
             
             let graph = prepareViewGraph(view: view)
             graph.accept(visitor: ViewSetRectVisitor())
+            XCTAssertTrue(graph.anyView is ModifiedContent<Text, Modifier>)
+            XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
             
-
-            XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2, height: "text".height + 1))
-            
-            let borderModifier = graph.children[0]
-            XCTAssertTrue(borderModifier.anyView is ModifiedContent<Text, _BorderModifier>)
-            XCTAssertEqual(borderModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
+            let wrappedModifier = graph.children[0]
+            XCTAssertTrue(wrappedModifier.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BorderModifier>)
+            XCTAssertEqual(wrappedModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
     }
 

--- a/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
@@ -1,0 +1,34 @@
+//
+//  ModifierContentTests.swift
+//  SwiftTUITests
+//
+//  Created by Yudai.Hirose on 2020/04/12.
+//
+
+import XCTest
+@testable import SwiftTUI
+
+class ModifierContentTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        mainScreen = DummyScreen.init()
+    }
+
+    func testSize() throws {
+        XCTContext.runActivity(named: "with border modifier") { _ in
+            struct BorderModifier: ViewModifier {
+                func body(content: Content) -> some View {
+                    content.border(.red)
+                }
+            }
+            let view = Text("text").modifier(BorderModifier())
+            
+            let graph = prepareViewGraph(view: view)
+            graph.accept(visitor: ViewSetRectVisitor())
+            
+            XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2, height: "text".height + 1))
+        }
+    }
+
+}

--- a/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
+++ b/Tests/SwiftTUITests/Primitive/ModifierContentTests.swift
@@ -27,7 +27,12 @@ class ModifierContentTests: XCTestCase {
             let graph = prepareViewGraph(view: view)
             graph.accept(visitor: ViewSetRectVisitor())
             
+
             XCTAssertEqual(graph.rect.size, Size(width: "text".width + 2, height: "text".height + 1))
+            
+            let borderModifier = graph.children[0]
+            XCTAssertTrue(borderModifier.anyView is ModifiedContent<Text, _BorderModifier>)
+            XCTAssertEqual(borderModifier.rect.size, Size(width: "text".width + 2, height: "text".height + 2))
         }
     }
 

--- a/Tests/SwiftTUITests/ViewGraphSetVisitorTests.swift
+++ b/Tests/SwiftTUITests/ViewGraphSetVisitorTests.swift
@@ -328,13 +328,22 @@ class ViewGraphSetVisitorTests: XCTestCase {
                 XCTAssertFalse(graph.isUserDefinedView)
                 XCTAssertTrue(graph.isModifiedContent)
                 
-                XCTContext.runActivity(named: "And check children view of Text") { (_) in
+                XCTContext.runActivity(named: "And check children view of ModifiedContent<_ViewModifier_Content<Modifier>, _BackgroundModifier<Color>>") { (_) in
                     graph.children.forEach { child in
-                        XCTAssertTrue(child.anyView is Text)
-                        XCTAssertTrue(child.children.isEmpty)
+                        XCTAssertTrue(child.anyView is ModifiedContent<_ViewModifier_Content<Modifier>, _BackgroundModifier<Color>>)
+                        XCTAssertEqual(child.children.count, 1)
                         XCTAssertFalse(child.isRoot)
                         XCTAssertFalse(child.isUserDefinedView)
-                        XCTAssertFalse(child.isModifiedContent)
+                        XCTAssertTrue(child.isModifiedContent)
+                    }
+                    XCTContext.runActivity(named: "And check children view of Text") { (_) in
+                        graph.children[0].children.forEach { child in
+                            XCTAssertTrue(child.anyView is Text)
+                            XCTAssertTrue(child.children.isEmpty)
+                            XCTAssertFalse(child.isRoot)
+                            XCTAssertFalse(child.isUserDefinedView)
+                            XCTAssertFalse(child.isModifiedContent)
+                        }
                     }
                 }
             }

--- a/Tests/SwiftTUITests/ViewGraphSetVisitorTests.swift
+++ b/Tests/SwiftTUITests/ViewGraphSetVisitorTests.swift
@@ -336,8 +336,9 @@ class ViewGraphSetVisitorTests: XCTestCase {
                         XCTAssertFalse(child.isUserDefinedView)
                         XCTAssertTrue(child.isModifiedContent)
                     }
+                    XCTAssertTrue(graph.children[0].children[0].anyView is _ViewModifier_Content<Modifier>)
                     XCTContext.runActivity(named: "And check children view of Text") { (_) in
-                        graph.children[0].children.forEach { child in
+                        graph.children[0].children[0].children.forEach { child in
                             XCTAssertTrue(child.anyView is Text)
                             XCTAssertTrue(child.children.isEmpty)
                             XCTAssertFalse(child.isRoot)


### PR DESCRIPTION
## ⛏  Details of Changes
- Set proposedSize from parent of already proposedSize set.
- Add test case for CustomModifedContent
- Switching set ViewGraph when current is user defined modifier.
- No strict fatalError condition for _BorderModifier when set content. Because visitor.current not update when it is accepted user defined modifier.

## ❓ Why


## ✅ Check List
#### 📝 Writing Tests 
* [x] test self sizing
* [x] test chlid position
* [x] test setting content
* [ ] ~test with container VStack or HStack~
* [x] check dry-run

## 📸 Screenshots
![image](https://user-images.githubusercontent.com/10897361/79069780-f19e0a00-7d0b-11ea-90b3-07315ce33e9d.png)

