### PR TITLE
fix root view default position to center

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 * [ ] test self sizing
 * [ ] test chlid position
 * [ ] test setting content
-* [ ] test with container VStack or HStack 
+* [ ] test with container VStack or HStack
 * [ ] check dry-run
 
 ## 📸 Screenshots

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -180,6 +180,11 @@ extension ViewGraph {
                 acceptSize(visitor: visitor)
                 acceptSetPosition(visitor: visitor)
                 acceptSetContainerSize(visitor: visitor)
+                
+                if children.count == 1 {
+                    let child = children[0]
+                    rect.origin = Point(x: (mainScreen.bounds.size.width - child.rect.size.width) / 2, y: (mainScreen.bounds.size.height - child.rect.size.height) / 2)
+                }
             }
         }
         


### PR DESCRIPTION
## ⛏  Details of Changes
- fix rootview position to center

## ❓ Why
this is SwiftUI standard behavior


## ✅ Check List
#### 📝 Writing Tests 
* [ ] ~test self sizing~
* [ ] ~test chlid position~
* [ ] ~test setting content~
* [ ] ~test with container VStack or HStack~
* [ ] ~check dry-run~

## 📸 Screenshots
![image](https://user-images.githubusercontent.com/10897361/79703757-ac1fa500-82e8-11ea-9030-80e6226e03a7.png)