### PR TITLE
bugfix of out of bounds for BorderModifier

### DIFF
--- a/Sources/Demo/main.swift
+++ b/Sources/Demo/main.swift
@@ -48,7 +48,11 @@ struct ParentView: View {
     }
 }
 var state = State(initialValue: false)
-let view = ParentView(state: state)
+let view = VStack {
+    Text("Hello")
+    Text(",").padding(40).border(Color.red)
+    Text("World")
+}
 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
     state.wrappedValue = true
     state.update()

--- a/Sources/Demo/main.swift
+++ b/Sources/Demo/main.swift
@@ -48,11 +48,7 @@ struct ParentView: View {
     }
 }
 var state = State(initialValue: false)
-let view = VStack {
-    Text("Hello")
-    Text(",").padding(40).border(Color.red)
-    Text("World")
-}
+let view = ParentView(state: state)
 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
     state.wrappedValue = true
     state.update()

--- a/Sources/Demo/main.swift
+++ b/Sources/Demo/main.swift
@@ -22,11 +22,15 @@ struct ChildView: View {
                     Text("Hello")
                 }
                 .border(Color.red)
+                .padding(20)
+                .border(Color.red)
             } else {
                 ForEach(0..<3) { _ in
                     Text("World")
                 }
                 .border(Color.blue)
+                .padding(20)
+                .border(Color.red)
             }
         }
         .border(.cyan)

--- a/Sources/SwiftTUI/Application/HostViewController.swift
+++ b/Sources/SwiftTUI/Application/HostViewController.swift
@@ -92,13 +92,16 @@ extension HostViewController: Drawable, DrawableDriver {
         drawnContent.append(rune)
         debugLogger.debug(userInfo: "point is \(point)")
         debugLogger.debug(userInfo: "window size is \(window.frame.size)")
-        switch point.x < window.frame.size.width {
-        case true:
+        
+        switch (point.x < window.frame.size.width, point.y < window.frame.size.height) {
+        case (true, true):
             sharedCursor.moveTo(x: point.x + 1, y: point.y)
-        case false:
+        case (false, true):
             sharedCursor.moveTo(x: 0, y: point.y + 1)
+        case (true, false), (false, false):
+            break
         }
-        debugLogger.debug(userInfo: "end rune: \(rune)")
+        debugLogger.debug(userInfo: "end add rune: \(rune)")
     }
     
     func setBackgroundColor(_ color: Color) {

--- a/Sources/SwiftTUI/Application/HostViewController.swift
+++ b/Sources/SwiftTUI/Application/HostViewController.swift
@@ -61,10 +61,12 @@ internal protocol AttributeRestorer {
 
 extension AttributeRestorer where Self: AttributeSetter {
     func restoreForegroundColor() {
+        debugLogger.debug()
         setForegroundColor(Style.Color.foreground.color)
         keepForegroundColor = nil
     }
     func restoreBackgroundColor() {
+        debugLogger.debug()
         setBackgroundColor(Style.Color.background.color)
         keepBackgroundColor = nil
     }
@@ -80,28 +82,21 @@ fileprivate var pairNumber: Int32 = 2
 extension HostViewController: Drawable, DrawableDriver {
     func add(rune: Rune) {
         let point = drawPoint()
-        if point.x > window.frame.size.width {
-            return
-        }
-        if point.y > window.frame.size.height {
-            return
-        }
-        
-        debugLogger.debug(userInfo: "start add rune: \(rune)")
-        cncurses.addch(rune)
-        drawnContent.append(rune)
-        debugLogger.debug(userInfo: "point is \(point)")
-        debugLogger.debug(userInfo: "window size is \(window.frame.size)")
-        
+        debugLogger.debug(userInfo: "start add rune: \(rune), point is \(point), window size is \(window.frame.size)")
+        defer { debugLogger.debug(userInfo: "end add rune: \(rune)") }
+
         switch (point.x < window.frame.size.width, point.y < window.frame.size.height) {
         case (true, true):
             sharedCursor.moveTo(x: point.x + 1, y: point.y)
         case (false, true):
             sharedCursor.moveTo(x: 0, y: point.y + 1)
         case (true, false), (false, false):
-            break
+            debugLogger.debug(userInfo: "Out of range \(rune)")
+            return
         }
-        debugLogger.debug(userInfo: "end add rune: \(rune)")
+        
+        cncurses.addch(rune)
+        drawnContent.append(rune)
     }
     
     func setBackgroundColor(_ color: Color) {

--- a/Sources/SwiftTUI/Application/HostViewController.swift
+++ b/Sources/SwiftTUI/Application/HostViewController.swift
@@ -79,12 +79,17 @@ fileprivate var pairNumber: Int32 = 2
 // MARK: - Draw on console
 extension HostViewController: Drawable, DrawableDriver {
     func add(rune: Rune) {
-        debugLogger.debug(userInfo: "start rune: \(rune)")
-
+        let point = drawPoint()
+        if point.x > window.frame.size.width {
+            return
+        }
+        if point.y > window.frame.size.height {
+            return
+        }
+        
+        debugLogger.debug(userInfo: "start add rune: \(rune)")
         cncurses.addch(rune)
         drawnContent.append(rune)
-
-        let point = drawPoint()
         debugLogger.debug(userInfo: "point is \(point)")
         debugLogger.debug(userInfo: "window size is \(window.frame.size)")
         switch point.x < window.frame.size.width {

--- a/Sources/SwiftTUI/Application/HostViewController.swift
+++ b/Sources/SwiftTUI/Application/HostViewController.swift
@@ -40,9 +40,9 @@ extension ContentSetter {
     }
     
     func add(string: String) {
-        debugLogger.debug(userInfo: "start string: \(string)")
+        debugLogger.debug(userInfo: "start add string: \(string)")
         string.forEach(add(character:))
-        debugLogger.debug(userInfo: "end string: \(string)")
+        debugLogger.debug(userInfo: "end add string: \(string)")
     }
 }
 

--- a/Sources/SwiftTUI/Core/ModifierContent.swift
+++ b/Sources/SwiftTUI/Core/ModifierContent.swift
@@ -26,12 +26,14 @@ extension ModifiedContent: ViewContentAcceptable {
     internal func accept<V: ViewContentVisitor>(visitor: V) -> V.VisitResult {
         debugLogger.debug()
         if let modifier = modifier as? ViewContentAcceptable {
+            debugLogger.debug()
             modifier.accept(visitor: visitor)
             return
         }
 
         if content is UserDefinedViewModifierContent {
             assert(visitor.current?.children.count == 0)
+            debugLogger.debug()
             visitor.current?.children.forEach(visitor.visit)
             return
         }

--- a/Sources/SwiftTUI/Curses/Cursor.swift
+++ b/Sources/SwiftTUI/Curses/Cursor.swift
@@ -29,6 +29,7 @@ extension CursorImpl: Cursor {
         moveTo(x: point.x, y: point.y)
     }
     mutating func moveTo(x: PhysicalDistance, y: PhysicalDistance) {
+        debugLogger.debug(userInfo: "x: \(x), y: \(y)")
         self.x = x
         self.y = y
         cncurses.move(Int32(y), Int32(x))

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -107,11 +107,13 @@ extension _BorderModifier: ViewContentAcceptable {
             let top = position.y + 1
             let bottom = position.y + graph.rect.size.height - 2
             let setter: (Int) -> Void = { offset in
-                sharedCursor.moveTo(x: position.x, y: top + offset)
-                visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
-                
-                sharedCursor.moveTo(x: position.x + graph.rect.size.width - 1, y: top + offset)
-                visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
+                if top + offset < graph.proposedSize.height {
+                    sharedCursor.moveTo(x: position.x, y: top + offset)
+                    visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
+                    
+                    sharedCursor.moveTo(x: position.x + graph.rect.size.width - 1, y: top + offset)
+                    visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
+                }
             }
             stride(from: top, through: bottom, by: Edge.Set.vertical.defaultDelimiter.height).forEach { offset in
                 setter(offset - top)

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -58,10 +58,9 @@ internal extension _BorderModifier {
         
         assert(!graph.rendableChildren.isEmpty, "it is necessary about rendable view")
         graph.rendableChildren.forEach { baseGraph in
-            baseGraph.proposedSize.width = graph.proposedSize.width - horizontalLength
-            baseGraph.proposedSize.height = graph.proposedSize.height - verticalLength
-
+            baseGraph.setProposedSizeIfFirst(Size(width: graph.proposedSize.width - horizontalLength, height: graph.proposedSize.height - verticalLength))
             baseGraph.acceptSize(visitor: visitor)
+            
             graph.rect.size.width = max(graph.rect.size.width, baseGraph.rect.size.width + horizontalLength)
             graph.rect.size.height = max(graph.rect.size.height, baseGraph.rect.size.height + verticalLength)
 

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -106,13 +106,11 @@ extension _BorderModifier: ViewContentAcceptable {
             let top = position.y + 1
             let bottom = position.y + graph.rect.size.height - 2
             let setter: (Int) -> Void = { offset in
-                if top + offset < graph.proposedSize.height {
-                    sharedCursor.moveTo(x: position.x, y: top + offset)
-                    visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
-                    
-                    sharedCursor.moveTo(x: position.x + graph.rect.size.width - 1, y: top + offset)
-                    visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
-                }
+                sharedCursor.moveTo(x: position.x, y: top + offset)
+                visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
+                
+                sharedCursor.moveTo(x: position.x + graph.rect.size.width - 1, y: top + offset)
+                visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)
             }
             stride(from: top, through: bottom, by: Edge.Set.vertical.defaultDelimiter.height).forEach { offset in
                 setter(offset - top)

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -78,7 +78,7 @@ internal extension _BorderModifier {
     private func horizontalLength() -> PhysicalDistance {
         var length = 0
         if edges.contains(.leading) { length = length + defaultBorderWidth }
-        if edges.contains(.trailing) { length = length + defaultPadding }
+        if edges.contains(.trailing) { length = length + defaultBorderWidth }
         return length
     }
 }

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -87,7 +87,6 @@ extension _BorderModifier: ViewContentAcceptable {
             fatalError("visitor.current necessary but it is nil")
         }
         let position = graph.positionToWindow()
-        debugLogger.debug(userInfo: "position: \(position), graph.rect.size: \(graph.rect.size)")
         
         visitor.driver.setForegroundColor(color)
         defer { visitor.driver.restoreForegroundColor() }
@@ -107,7 +106,6 @@ extension _BorderModifier: ViewContentAcceptable {
             let top = position.y + 1
             let bottom = position.y + graph.rect.size.height - 2
             let setter: (Int) -> Void = { offset in
-                debugLogger.debug(userInfo: "condition: \(top + offset < graph.proposedSize.height), top: \(top), offset: \(offset), proposedSize: \(graph.proposedSize.height)")
                 if top + offset < graph.proposedSize.height {
                     sharedCursor.moveTo(x: position.x, y: top + offset)
                     visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)

--- a/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
+++ b/Sources/SwiftTUI/View/Modifier/BorderModifier.swift
@@ -87,6 +87,7 @@ extension _BorderModifier: ViewContentAcceptable {
             fatalError("visitor.current necessary but it is nil")
         }
         let position = graph.positionToWindow()
+        debugLogger.debug(userInfo: "position: \(position), graph.rect.size: \(graph.rect.size)")
         
         visitor.driver.setForegroundColor(color)
         defer { visitor.driver.restoreForegroundColor() }
@@ -106,6 +107,7 @@ extension _BorderModifier: ViewContentAcceptable {
             let top = position.y + 1
             let bottom = position.y + graph.rect.size.height - 2
             let setter: (Int) -> Void = { offset in
+                debugLogger.debug(userInfo: "condition: \(top + offset < graph.proposedSize.height), top: \(top), offset: \(offset), proposedSize: \(graph.proposedSize.height)")
                 if top + offset < graph.proposedSize.height {
                     sharedCursor.moveTo(x: position.x, y: top + offset)
                     visitor.driver.add(string: Edge.Set.vertical.defaultDelimiter)

--- a/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
+++ b/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
@@ -67,8 +67,8 @@ internal let defaultPadding = 1
 
 internal extension _PaddingLayout {
      func modifySize(for paddingGraph: ViewGraph, visitor: ViewSetRectVisitor) {
-        let horizontalLength = self.horizontalLength()
-        let verticalLength = self.verticalLength()
+        let horizontalLength = self.horizontalLength(graph: paddingGraph)
+        let verticalLength = self.verticalLength(graph: paddingGraph)
 
         assert(!paddingGraph.rendableChildren.isEmpty, "it is necessary about rendable view")
         paddingGraph.rendableChildren.forEach { baseGraph in
@@ -82,16 +82,18 @@ internal extension _PaddingLayout {
             if edges.contains(.top) { baseGraph.rect.origin.y = (insets?.top ?? defaultPadding) }
         }
     }
-    private func verticalLength() -> PhysicalDistance {
+    private func verticalLength(graph: ViewGraph) -> PhysicalDistance {
         var length = 0
-        if edges.contains(.top) { length = length + (insets?.top ?? defaultPadding) }
-        if edges.contains(.bottom) { length = length + (insets?.bottom ?? defaultPadding) }
+        let maxHeight = graph.proposedSize.height / 2
+        if edges.contains(.top) { length = length + min((insets?.top ?? defaultPadding), maxHeight) }
+        if edges.contains(.bottom) { length = length + min((insets?.bottom ?? defaultPadding), maxHeight) }
         return length
     }
-    private func horizontalLength() -> PhysicalDistance {
+    private func horizontalLength(graph: ViewGraph) -> PhysicalDistance {
         var length = 0
-        if edges.contains(.leading) { length = length + (insets?.leading ?? defaultPadding) }
-        if edges.contains(.trailing) { length = length + (insets?.trailing ?? defaultPadding) }
+        let maxWidth = graph.proposedSize.width / 2
+        if edges.contains(.leading) { length = length + min((insets?.leading ?? defaultPadding), maxWidth) }
+        if edges.contains(.trailing) { length = length + min((insets?.trailing ?? defaultPadding), maxWidth) }
         return length
     }
 }

--- a/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
+++ b/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
@@ -66,17 +66,17 @@ internal let defaultPadding = 1
 }
 
 internal extension _PaddingLayout {
-     func modifySize(for paddingGraph: ViewGraph, visitor: ViewSetRectVisitor) {
-        let horizontalLength = self.horizontalLength(graph: paddingGraph)
-        let verticalLength = self.verticalLength(graph: paddingGraph)
+     func modifySize(for graph: ViewGraph, visitor: ViewSetRectVisitor) {
+        let horizontalLength = self.horizontalLength(graph: graph)
+        let verticalLength = self.verticalLength(graph: graph)
 
-        assert(!paddingGraph.rendableChildren.isEmpty, "it is necessary about rendable view")
-        paddingGraph.rendableChildren.forEach { baseGraph in
-            baseGraph.setProposedSizeIfFirst(Size(width: paddingGraph.proposedSize.width - horizontalLength, height: paddingGraph.proposedSize.height - verticalLength))
+        assert(!graph.rendableChildren.isEmpty, "it is necessary about rendable view")
+        graph.rendableChildren.forEach { baseGraph in
+            baseGraph.setProposedSizeIfFirst(Size(width: graph.proposedSize.width - horizontalLength, height: graph.proposedSize.height - verticalLength))
             baseGraph.acceptSize(visitor: visitor)
 
-            paddingGraph.rect.size.width = max(paddingGraph.rect.size.width, baseGraph.rect.size.width + horizontalLength)
-            paddingGraph.rect.size.height = max(paddingGraph.rect.size.height, baseGraph.rect.size.height + verticalLength)
+            graph.rect.size.width = max(graph.rect.size.width, baseGraph.rect.size.width + horizontalLength)
+            graph.rect.size.height = max(graph.rect.size.height, baseGraph.rect.size.height + verticalLength)
 
             if edges.contains(.leading) { baseGraph.rect.origin.x = (insets?.leading ?? defaultPadding) }
             if edges.contains(.top) { baseGraph.rect.origin.y = (insets?.top ?? defaultPadding) }

--- a/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
+++ b/Sources/SwiftTUI/View/Modifier/PaddingLayout.swift
@@ -78,8 +78,8 @@ internal extension _PaddingLayout {
             graph.rect.size.width = max(graph.rect.size.width, baseGraph.rect.size.width + horizontalLength)
             graph.rect.size.height = max(graph.rect.size.height, baseGraph.rect.size.height + verticalLength)
 
-            if edges.contains(.leading) { baseGraph.rect.origin.x = (insets?.leading ?? defaultPadding) }
-            if edges.contains(.top) { baseGraph.rect.origin.y = (insets?.top ?? defaultPadding) }
+            if edges.contains(.leading) { baseGraph.rect.origin.x = min(graph.proposedSize.width / 2, (insets?.leading ?? defaultPadding)) }
+            if edges.contains(.top) { baseGraph.rect.origin.y = min(graph.proposedSize.height / 2, (insets?.top ?? defaultPadding)) }
         }
     }
     private func verticalLength(graph: ViewGraph) -> PhysicalDistance {

--- a/Sources/SwiftTUI/View/Stack/HasContainerContentSize.swift
+++ b/Sources/SwiftTUI/View/Stack/HasContainerContentSize.swift
@@ -18,10 +18,6 @@ extension HasContainerContentSize {
         switch viewGraph.listType {
         case .vertical:
             var allocableHeight: PhysicalDistance = viewGraph.proposedSize.height - (rendableChildren.count - 1) * viewGraph.spacing
-            let sumHeight = rendableChildren.map(\.rect.size.height).reduce(0, +)
-            if sumHeight > allocableHeight {
-                rendableChildren.forEach
-            }
             var maxElementWidth: PhysicalDistance = 0
             rendableChildren.enumerated().forEach { (offset, element) in
                 let provisionalElementHeight: PhysicalDistance = allocableHeight / (rendableChildren.count - offset)

--- a/Sources/SwiftTUI/View/Stack/HasContainerContentSize.swift
+++ b/Sources/SwiftTUI/View/Stack/HasContainerContentSize.swift
@@ -18,6 +18,10 @@ extension HasContainerContentSize {
         switch viewGraph.listType {
         case .vertical:
             var allocableHeight: PhysicalDistance = viewGraph.proposedSize.height - (rendableChildren.count - 1) * viewGraph.spacing
+            let sumHeight = rendableChildren.map(\.rect.size.height).reduce(0, +)
+            if sumHeight > allocableHeight {
+                rendableChildren.forEach
+            }
             var maxElementWidth: PhysicalDistance = 0
             rendableChildren.enumerated().forEach { (offset, element) in
                 let provisionalElementHeight: PhysicalDistance = allocableHeight / (rendableChildren.count - offset)

--- a/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
+++ b/Sources/SwiftTUI/View/ViewGraph/ViewGraph+Visitor.swift
@@ -46,7 +46,6 @@ extension ViewGraph {
         }
         
         if isContainerType {
-            children.forEach { $0.acceptSize(visitor: visitor) }
             acceptSetContainerSize(visitor: visitor)
             return
         }

--- a/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
+++ b/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
@@ -181,11 +181,11 @@ class BorderModifierTests: XCTestCase {
             XCTAssertTrue(driver.storedForegroundColors.contains(.red))
             XCTAssertEqual(driver.storedForegroundColors.last, Style.Color.foreground.color)
             XCTAssertEqual(subject(cornerDelimiter), 1 * 4)
-            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 99 * 2)
-            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 99 * 2)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 98 * 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 98 * 2)
         }
     }
-    
+
     func testModifiers() {
         struct Modifier: ViewModifier {
             func body(content: Content) -> some View {
@@ -214,6 +214,5 @@ class BorderModifierTests: XCTestCase {
             XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 5 * 2)
             XCTAssertTrue(content.contains("Hello"))
         }
-
     }
 }

--- a/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
+++ b/Tests/SwiftTUITests/Primitive/BorderModifierTests.swift
@@ -162,6 +162,28 @@ class BorderModifierTests: XCTestCase {
             XCTAssertTrue(content.contains(","))
             XCTAssertTrue(content.contains("World"))
         }
+        XCTContext.runActivity(named: "Keep from proposedSize") { _ in
+            let view = Text("").padding(110).border(Color.red)
+            
+            let graph = prepareSizedGraph(view: view)
+            let driver = Driver()
+            let visitor = ViewContentVisitor(driver: driver)
+            graph.accept(visitor: visitor)
+            
+            XCTAssert(graph.proposedSize == mainScreen.bounds.size)
+            
+            let content = driver.content()
+            let subject: (String) -> Int = { (delimiter: String) in
+                content.filter { String($0) == delimiter }.count
+            }
+            let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
+
+            XCTAssertTrue(driver.storedForegroundColors.contains(.red))
+            XCTAssertEqual(driver.storedForegroundColors.last, Style.Color.foreground.color)
+            XCTAssertEqual(subject(cornerDelimiter), 1 * 4)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 99 * 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 99 * 2)
+        }
     }
     
     func testModifiers() {

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -927,6 +927,7 @@ extension VStackTests {
                 }
             }
         }
+        
         XCTContext.runActivity(named: "when VStack contains TupleView<Text, ModifiedContent<ModifiedContent<Text, _PaddingLayout> _BackgroundModifier>, Text>") { (_) in
             let view = VStack {
                 Text("Hello")
@@ -1077,6 +1078,30 @@ extension VStackTests {
             
             XCTAssertEqual(graph.rect.size.width, 5)
             XCTAssertEqual(graph.rect.size.height, 5)
+        }
+    }
+    func testChildContentWithBorder() {
+        XCTContext.runActivity(named: "when VStack contains TupleView<Text, ModifiedContent<ModifiedContent<Text, _PaddingLayout> _BackgroundModifier>, Text>") { (_) in
+            let view = VStack {
+                Text("Hello")
+                Text(",").padding(110).border(Color.blue)
+                Text("World")
+            }
+            
+            let driver = Driver()
+            let visitor = ViewContentVisitor(driver: driver)
+            let graph = prepareSizedGraph(view: view)
+            visitor.visit(graph)
+            
+            let content = driver.content()
+            let subject: (String) -> Int = { (delimiter: String) in
+                content.filter { String($0) == delimiter }.count
+            }
+            
+            let cornerDelimiter = Edge.Set.leadingTop.defaultDelimiter
+            XCTAssertEqual(subject(cornerDelimiter), 1 * 4)
+            XCTAssertEqual(subject(Edge.Set.vertical.defaultDelimiter), 98 * 2 - 2)
+            XCTAssertEqual(subject(Edge.Set.horizontal.defaultDelimiter), 98 * 2)
         }
     }
 }

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -927,6 +927,8 @@ extension VStackTests {
                 }
             }
         }
+    }
+    func test_playground() {
         XCTContext.runActivity(named: "when VStack contains TupleView<Text, ModifiedContent<ModifiedContent<Text, _PaddingLayout> _BackgroundModifier>, Text>") { (_) in
             let view = VStack {
                 Text("Hello")

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -972,11 +972,11 @@ extension VStackTests {
                     XCTAssertEqual(paddingGraph.rect.origin.x, 1)
                     XCTAssertEqual(paddingGraph.rect.origin.y, 1)
                     XCTAssertEqual(paddingGraph.rect.size.width, 98)
-                    XCTAssertEqual(paddingGraph.rect.size.height, 98)
+                    XCTAssertEqual(paddingGraph.rect.size.height, 96)
                     XCTAssertEqual(blueBorderGraph.rect.origin.x, 0)
                     XCTAssertEqual(blueBorderGraph.rect.origin.y, 1)
                     XCTAssertEqual(blueBorderGraph.rect.size.width, 100)
-                    XCTAssertEqual(blueBorderGraph.rect.size.height, 100)
+                    XCTAssertEqual(blueBorderGraph.rect.size.height, 98)
                 }
                 third: do {
                     let textGraph = graph.children[0].children[2]

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -928,6 +928,66 @@ extension VStackTests {
             }
         }
     }
+    func test_playground() {
+        XCTContext.runActivity(named: "when VStack contains TupleView<Text, ModifiedContent<ModifiedContent<Text, _PaddingLayout> _BackgroundModifier>, Text>") { (_) in
+            let view = VStack {
+                Text("Hello")
+                Text(",").padding(110).border(Color.blue)
+                Text("World")
+            }
+
+            let graph = prepareViewGraph(view: view)
+            let visitor = ViewSetRectVisitor()
+            graph.accept(visitor: visitor)
+            
+            XCTAssertEqual(graph.rect.origin.x, 0)
+            XCTAssertEqual(graph.rect.origin.y, 0)
+            
+            XCTContext.runActivity(named: "Child graph confirm to trailing position") { (_) in
+                first: do {
+                    let textGraph = graph.children[0].children[0]
+                    
+                    XCTAssertTrue(textGraph.anyView is Text)
+                    let text = textGraph.anyView as! Text
+                    
+                    XCTAssertEqual(text.content, "Hello")
+                    XCTAssertEqual(textGraph.rect.origin.x, 48)
+                    XCTAssertEqual(textGraph.rect.origin.y, 0)
+                }
+                second: do {
+                    let blueBorderGraph = graph.children[0].children[1]
+                    let blueBorderModifier = blueBorderGraph.anyView as! HasAnyModifier
+                    XCTAssertTrue(blueBorderModifier.anyModifier is _BorderModifier)
+                    
+                    let paddingGraph = blueBorderGraph.children[0]
+                    let paddingModifier = paddingGraph.anyView as! HasAnyModifier
+                    XCTAssertTrue(paddingModifier.anyModifier is _PaddingLayout)
+                    
+                    let textGraph = paddingGraph.children[0]
+                    XCTAssertTrue(textGraph.anyView is Text)
+                    let text = textGraph.anyView as! Text
+                    
+                    XCTAssertEqual(text.content, ",")
+                    XCTAssertEqual(textGraph.rect.origin.x, 49)
+                    XCTAssertEqual(textGraph.rect.origin.y, 49)
+                    XCTAssertEqual(paddingGraph.rect.origin.x, 1)
+                    XCTAssertEqual(paddingGraph.rect.origin.y, 1)
+                    XCTAssertEqual(blueBorderGraph.rect.origin.x, 0)
+                    XCTAssertEqual(blueBorderGraph.rect.origin.y, 1)
+                }
+                third: do {
+                    let textGraph = graph.children[0].children[2]
+                    
+                    XCTAssertTrue(textGraph.anyView is Text)
+                    let text = textGraph.anyView as! Text
+                    
+                    XCTAssertEqual(text.content, "World")
+                    XCTAssertEqual(textGraph.rect.origin.x, 48)
+                    XCTAssertEqual(textGraph.rect.origin.y, 101)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - Children Content

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -927,8 +927,6 @@ extension VStackTests {
                 }
             }
         }
-    }
-    func test_playground() {
         XCTContext.runActivity(named: "when VStack contains TupleView<Text, ModifiedContent<ModifiedContent<Text, _PaddingLayout> _BackgroundModifier>, Text>") { (_) in
             let view = VStack {
                 Text("Hello")

--- a/Tests/SwiftTUITests/Primitive/VStackTests.swift
+++ b/Tests/SwiftTUITests/Primitive/VStackTests.swift
@@ -970,8 +970,12 @@ extension VStackTests {
                     XCTAssertEqual(textGraph.rect.origin.y, 49)
                     XCTAssertEqual(paddingGraph.rect.origin.x, 1)
                     XCTAssertEqual(paddingGraph.rect.origin.y, 1)
+                    XCTAssertEqual(paddingGraph.rect.size.width, 98)
+                    XCTAssertEqual(paddingGraph.rect.size.height, 98)
                     XCTAssertEqual(blueBorderGraph.rect.origin.x, 0)
                     XCTAssertEqual(blueBorderGraph.rect.origin.y, 1)
+                    XCTAssertEqual(blueBorderGraph.rect.size.width, 100)
+                    XCTAssertEqual(blueBorderGraph.rect.size.height, 100)
                 }
                 third: do {
                     let textGraph = graph.children[0].children[2]


### PR DESCRIPTION
## ⛏  Details of Changes
- :bug: Fix drawing border modifier when out of bounds. 
  * e.g) `Text("A").padding(40).border(Color.red)` 

## ❓ Why
It is necessary to control `add(rune:)` range.

## ✅ Check List
#### 📝 Writing Tests 
* [ ] test self sizing
* [ ] test chlid position
* [x] test setting content
* [ ] test with container VStack or HStack
* [x] check dry-run

## 📸 Screenshots